### PR TITLE
Add php-http/discovery requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": "^5.5 || ^7.0",
         "php-http/httplug": "^1.0",
         "php-http/client-implementation": "^1.0",
+        "php-http/discovery": "^1.0",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Project have a hard dependency on `php-http/discovery` in:

`Translation\Translator\Service\HttpTranslator` With

```
use Http\Discovery\HttpClientDiscovery;
use Http\Discovery\MessageFactoryDiscovery;
```