### PR TITLE
Support mutiple strings in same request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
+        "ext-mbstring": "*",
         "php-http/httplug": "^1.0",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
         <!-- API Keys -->
         <env name="YANDEX_KEY" value=""/>
         <env name="GOOGLE_KEY" value=""/>
+        <env name="BING_KEY" value=""/>
     </php>
 
     <filter>

--- a/src/Service/HttpTranslator.php
+++ b/src/Service/HttpTranslator.php
@@ -16,11 +16,12 @@ use Http\Client\HttpClient;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Message\RequestFactory;
+use Translation\Translator\TranslatorService;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-abstract class HttpTranslator
+abstract class HttpTranslator implements TranslatorService
 {
     /**
      * @var HttpClient
@@ -56,5 +57,50 @@ abstract class HttpTranslator
     protected function getRequestFactory()
     {
         return $this->requestFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function translateArray($strings, $from, $to)
+    {
+        $array = [];
+
+        foreach ($strings as $string) {
+            $array[] = $this->translate($string, $from, $to);
+        }
+
+        return $array;
+    }
+
+    /**
+     * @param string $original
+     * @param string $translationHtmlEncoded
+     *
+     * @return string
+     */
+    protected function format($original, $translationHtmlEncoded)
+    {
+        $translation = htmlspecialchars_decode($translationHtmlEncoded);
+
+        // if capitalized, make sure we also capitalize.
+        $firstChar = \mb_substr($original, 0, 1);
+        $originalIsUpper = \mb_strtoupper($firstChar) === $firstChar;
+
+        if ($originalIsUpper) {
+            $first = \mb_strtoupper(\mb_substr($translation, 0, 1));
+            $translation = $first.\mb_substr($translation, 1);
+        }
+
+        // also check on translated if capitalize and original isn't
+        $transFirstChar = \mb_substr($translationHtmlEncoded, 0, 1);
+        $translationIsUpper = \mb_strtoupper($transFirstChar) === $transFirstChar;
+
+        if (!$originalIsUpper && $translationIsUpper) {
+            $first = \mb_strtolower(\mb_substr($translation, 0, 1));
+            $translation = $first.\mb_substr($translation, 1);
+        }
+
+        return $translation;
     }
 }

--- a/src/Service/YandexTranslator.php
+++ b/src/Service/YandexTranslator.php
@@ -16,12 +16,11 @@ use Http\Client\HttpClient;
 use Http\Message\RequestFactory;
 use Psr\Http\Message\ResponseInterface;
 use Translation\Translator\Exception\ResponseException;
-use Translation\Translator\TranslatorService;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class YandexTranslator extends HttpTranslator implements TranslatorService
+class YandexTranslator extends HttpTranslator
 {
     /**
      * @var string
@@ -87,25 +86,5 @@ class YandexTranslator extends HttpTranslator implements TranslatorService
             $to,
             urlencode($string)
         );
-    }
-
-    /**
-     * @param string $original
-     * @param string $translationHtmlEncoded
-     *
-     * @return string
-     */
-    private function format($original, $translationHtmlEncoded)
-    {
-        $translation = htmlspecialchars_decode($translationHtmlEncoded);
-
-        // if capitalized, make sure we also capitalize.
-        $firstChar = mb_substr($original, 0, 1);
-        if (mb_strtoupper($firstChar) === $firstChar) {
-            $first = mb_strtoupper(mb_substr($translation, 0, 1));
-            $translation = $first.mb_substr($translation, 1);
-        }
-
-        return $translation;
     }
 }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -43,9 +43,23 @@ final class Translator implements LoggerAwareInterface, TranslatorService
      */
     public function translate($string, $from, $to)
     {
+        list($result) = $this->translateArray([$string], $from, $to);
+
+        return $result;
+    }
+
+    /**
+     * @param array  $strings
+     * @param string $from
+     * @param string $to
+     *
+     * @return null|array Null is return when all translators failed.
+     */
+    public function translateArray($strings, $from, $to)
+    {
         foreach ($this->translatorServices as $service) {
             try {
-                return $service->translate($string, $from, $to);
+                return $service->translateArray($strings, $from, $to);
             } catch (TranslatorException\NoTranslationFoundException $e) {
                 // Do nothing, try again.
             } catch (TranslatorException $e) {

--- a/src/TranslatorService.php
+++ b/src/TranslatorService.php
@@ -27,4 +27,15 @@ interface TranslatorService
      * @throws \Translation\Translator\Exception if we could not translate string
      */
     public function translate($string, $from, $to);
+
+    /**
+     * @param array  $strings array of strings to translate
+     * @param string $from    from what locale
+     * @param string $to      to what locale
+     *
+     * @return array Return the translated strings
+     *
+     * @throws \Translation\Translator\Exception if we could not translate string
+     */
+    public function translateArray($strings, $from, $to);
 }

--- a/tests/Integration/AbstractTranslatorTest.php
+++ b/tests/Integration/AbstractTranslatorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+namespace Translation\translator\tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use Translation\Translator\TranslatorService;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+abstract class AbstractTranslatorTest extends TestCase
+{
+    /**
+     * @var TranslatorService
+     */
+    protected $translator = null;
+
+    /**
+     * @var array
+     */
+    protected $requested = ['apple', 'cherry'];
+
+    /**
+     * @var array
+     */
+    protected $expected = ['pomme', 'cerise'];
+
+    /**
+     * @var string
+     */
+    protected $from = 'en';
+
+    /**
+     * @var string
+     */
+    protected $to = 'fr';
+
+    public function testTranslate()
+    {
+        if (null === $this->translator) {
+            $this->markTestSkipped('No translator set.');
+        }
+
+        $result = $this->translator->translate($this->requested[0], $this->from, $this->to);
+        $this->assertEquals($this->expected[0], $result);
+
+        $results = $this->translator->translateArray($this->requested, $this->from, $this->to);
+        $this->assertEquals($this->expected, $results);
+    }
+}

--- a/tests/Integration/BingTranslatorTest.php
+++ b/tests/Integration/BingTranslatorTest.php
@@ -12,18 +12,18 @@
 
 namespace Translation\translator\tests\Integration;
 
-use Translation\Translator\Service\GoogleTranslator;
+use Translation\Translator\Service\BingTranslator;
 
 /**
- * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
  */
-class GoogleTranslatorTest extends AbstractTranslatorTest
+class BingTranslatorTest extends AbstractTranslatorTest
 {
     public function setUp()
     {
-        $key = getenv('GOOGLE_KEY');
+        $key = getenv('BING_KEY');
         if (!empty($key)) {
-            $this->translator = new GoogleTranslator($key);
+            $this->translator = new BingTranslator($key);
         }
     }
 }

--- a/tests/Integration/YandexTranslatorTest.php
+++ b/tests/Integration/YandexTranslatorTest.php
@@ -12,23 +12,28 @@
 
 namespace Translation\translator\tests\Integration;
 
-use PHPUnit\Framework\TestCase;
 use Translation\Translator\Service\YandexTranslator;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class YandexTranslatorTest extends TestCase
+class YandexTranslatorTest extends AbstractTranslatorTest
 {
-    public function testTranslate()
+    /**
+     * @var array
+     */
+    protected $expected = ['яблоко', 'вишня'];
+
+    /**
+     * @var string
+     */
+    protected $to = 'ru';
+
+    public function setUp()
     {
         $key = getenv('YANDEX_KEY');
-        if (empty($key)) {
-            $this->markTestSkipped('No Yandex key in environment');
+        if (!empty($key)) {
+            $this->translator = new YandexTranslator($key);
         }
-
-        $translator = new YandexTranslator($key);
-        $result = $translator->translate('apple', 'en', 'ru');
-        $this->assertEquals('яблоко', $result);
     }
 }


### PR DESCRIPTION
# Issues
- Fixes #13 

# Content
- Updating `TranslatorService` interface with `translateArray(array $strings, string $from, string $to): array` method.
- Creating `AbstractTranslator` to handle default behavior for `translateArray()` (which is just calling `translate()` method for all strings).
- Updating ChainedTranslator with new `translateArray()` method & updating `translate()` method.
- Moving `format()` method to `AbstractTranslator` & making it fixing translated string with first letter uppercase when original isn't.
- Abstracting translator tests & implementing it for all of them.