### PR TITLE
Drop HHVM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ matrix:
   include:
     - php: 5.5
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
-    - php: hhvm
-      dist: trusty
 
 install:
     - travis_retry composer update --prefer-dist --no-interaction


### PR DESCRIPTION
They dropped PHP support since Dec. 2018 and will stop making support on HHVM v3.30 on Nov. 2019.